### PR TITLE
Add gtksourceview2 to deps for machinekit-cnc

### DIFF
--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -9,7 +9,8 @@ Depends: machinekit-hal-posix, ${shlibs:Depends}, python-gnome2,
     python-glade2, python-vte, python-xlib, python-gtkglext1, 
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot, 
     tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1, 
-    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6,
+    libgtksourceview2.0-common, libgtksourceview2.0-0, python-gtksourceview2
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic

--- a/debian/control.posix.in
+++ b/debian/control.posix.in
@@ -9,7 +9,8 @@ Depends: machinekit-hal-posix, ${shlibs:Depends}, python-gnome2,
     python-glade2, python-vte, python-xlib, python-gtkglext1, 
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot, 
     tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1, 
-    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6,
+    libgtksourceview2.0-common, libgtksourceview2.0-0, python-gtksourceview2
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -10,7 +10,8 @@ Depends: machinekit-hal-rt-preempt, python-gnome2, ${shlibs:Depends},
     python-glade2, python-vte, python-xlib, python-gtkglext1,
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,
     tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1,
-    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6,
+    libgtksourceview2.0-common, libgtksourceview2.0-0, python-gtksourceview2
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -10,7 +10,8 @@ Depends: machinekit-hal-rt-preempt, python-gnome2, ${shlibs:Depends},
     python-glade2, python-vte, python-xlib, python-gtkglext1,
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,
     tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1,
-    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6,
+    libgtksourceview2.0-common, libgtksourceview2.0-0, python-gtksourceview2
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic

--- a/debian/control.xenomai-stretch.in
+++ b/debian/control.xenomai-stretch.in
@@ -9,7 +9,8 @@ Depends: machinekit-hal-xenomai, python-gnome2, ${shlibs:Depends}, xenomai-runti
     python-glade2, python-vte, python-xlib, python-gtkglext1,
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,
     tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1,
-    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6,
+    libgtksourceview2.0-common, libgtksourceview2.0-0, python-gtksourceview2
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -9,7 +9,8 @@ Depends: machinekit-hal-xenomai, python-gnome2, ${shlibs:Depends}, xenomai-runti
     python-glade2, python-vte, python-xlib, python-gtkglext1,
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,
     tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1,
-    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6,
+    libgtksourceview2.0-common, libgtksourceview2.0-0, python-gtksourceview2
 Description: PC based motion controller for real-time Linux
  Machinekit is the next-generation Enhanced Machine Controller which
  provides motion control for CNC machine tools and robotic


### PR DESCRIPTION
Used by a widget in gladevcp, unsure if other usages.
Was going to be deprecated by Debian, but appears available all the
way up to sid for now.

Signed-off-by: Mick <arceye@mgware.co.uk>