### PR TITLE
Revert build of hal.so required for tcl, within machinekit-cnc

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -800,7 +800,6 @@ endif
 	$(FILE) Makefile.inc $(DESTDIR)$(datadir)/linuxcnc
 	$(EXE) $(TCL) $(DESTDIR)$(tcldir)
 	$(FILE) ../tcl/linuxcnc.so $(DESTDIR)$(tcldir)
-	$(FILE) ../tcl/hal.so $(DESTDIR)$(tcldir)
 	$(FILE) ../tcl/pkgIndex.tcl $(DESTDIR)$(tcldir)
 	$(EXE) $(TCL_BIN) $(DESTDIR)$(tcldir)/bin
 	$(FILE) ../tcl/scripts/balloon.tcl ../tcl/scripts/emchelp.tcl $(DESTDIR)$(tcldir)/scripts

--- a/src/emc/usr_intf/Submakefile
+++ b/src/emc/usr_intf/Submakefile
@@ -54,15 +54,6 @@ endif
 	$(Q)$(CXX) -shared $(LDFLAGS) -o $@ $(TCL_CFLAGS) $^ $(TCL_LIBS) -lXinerama
 TARGETS += ../tcl/linuxcnc.so
 
-../tcl/hal.so: $(call TOOBJS, $(HALSHSRCS)) \
-	../lib/liblinuxcncini.so.0 \
-	../lib/libmachinetalk-pb2++.so.0 \
-	../lib/libmtalk.so.0 \
-	../lib/librtapi_math.so.0
-	$(ECHO) Linking $(notdir $@)
-	$(Q)$(CC) $(LDFLAGS) -shared $^  -o $@ -L../lib -llinuxcnchal
-TARGETS += ../tcl/hal.so
-
 ../bin/linuxcncrsh: $(call TOOBJS, $(EMCRSHSRCS)) \
 	../lib/liblinuxcnc.a \
 	../lib/libnml.so.0 \


### PR DESCRIPTION
However incovenient it is to build in machinekit-hal, the
alternative is to pull in lots of artifacts from that build
to build it in machinekit-cnc, which is messy and complicated.

Will move this to machinekit-hal and create dirs etc there.

Signed-off-by: Mick <arceye@mgware.co.uk>