### PR TITLE
Amend deps to reflect Buster does not have python-vte

### DIFF
--- a/debian/configure
+++ b/debian/configure
@@ -36,10 +36,15 @@ rules_enable_threads() {
 do_posix() {
     ## Jessie uses python-imaging, python-imaging-tk, python-gst-0.10
     ## Stretch and above use python-pil, python-pil.imagetk, python-gst-1.0
+    ## Buster does not have python-vte
     if [ "$DISTRO_CODENAME" == "jessie" ]; then
 	cat control.posix.in >> control
     else
-        cat control.posix-stretch.in >> control
+	if [ "$DISTRO_CODENAME" == "buster" ]; then
+    	    cat control.posix-buster.in >> control
+	else
+	    cat control.posix-stretch.in >> control
+	fi
     fi
     echo "debian/control:  added POSIX threads package" >&2
     rules_enable_threads posix
@@ -49,10 +54,15 @@ do_posix() {
 do_rt-preempt() {
     ## Jessie uses python-imaging, python-imaging-tk, python-gst-0.10
     ## Stretch and above use python-pil, python-pil.imagetk, python-gst-1.0
+    ## Buster does not have python-vte
     if [ "$DISTRO_CODENAME" == "jessie" ]; then
 	cat control.rt-preempt.in >> control
     else
-        cat control.rt-preempt-stretch.in >> control
+	if [ "$DISTRO_CODENAME" == "buster" ]; then
+    	    cat control.rt-preempt-buster.in >> control
+	else
+	    cat control.rt-preempt-stretch.in >> control
+	fi
     fi
     echo "debian/control:  added RT_PREEMPT threads package" >&2
     
@@ -63,10 +73,15 @@ do_rt-preempt() {
 do_xenomai() {
     ## Jessie uses python-imaging, python-imaging-tk, python-gst-0.10
     ## Stretch and above use python-pil, python-pil.imagetk, python-gst-1.0
+    ## Buster does not have python-vte
     if [ "$DISTRO_CODENAME" == "jessie" ]; then
 	cat control.xenomai.in >> control
     else
-        cat control.xenomai-stretch.in >> control
+	if [ "$DISTRO_CODENAME" == "buster" ]; then
+    	    cat control.xenomai-buster.in >> control
+	else
+	    cat control.xenomai-stretch.in >> control
+	fi
     fi
     echo "debian/control:  added xenomai threads package" >&2
 

--- a/debian/control.posix-buster.in
+++ b/debian/control.posix-buster.in
@@ -1,0 +1,19 @@
+
+Package: machinekit-cnc-posix
+Architecture: any
+Provides:  machinekit-cnc-posix
+Breaks: machinekit
+Enhances: machinekit-hal-posix
+Depends: machinekit-hal-posix, ${shlibs:Depends}, python-gnome2, 
+    python-tk, python-pil, python-pil.imagetk, python-gst-1.0,
+    python-glade2, python-xlib, python-gtkglext1, 
+    python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot, 
+    tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1, 
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+Description: PC based motion controller for real-time Linux
+ Machinekit is the next-generation Enhanced Machine Controller which
+ provides motion control for CNC machine tools and robotic
+ applications (milling, cutting, routing, etc.).
+ .
+ This package provides components and drivers that run on a non-realtime
+ (Posix) system.

--- a/debian/control.rt-preempt-buster.in
+++ b/debian/control.rt-preempt-buster.in
@@ -1,0 +1,19 @@
+
+Package: machinekit-cnc-rt-preempt
+Architecture: any
+Provides:  machinekit-cnc-rt-preempt
+Breaks: machinekit
+Enhances: machinekit-hal-rt-preempt
+Depends: machinekit-hal-rt-preempt, python-gnome2, ${shlibs:Depends},
+    linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64],
+    python-tk, python-pil, python-pil.imagetk, python-gst-1.0,
+    python-glade2, python-xlib, python-gtkglext1,
+    python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,
+    tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1,
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+Description: PC based motion controller for real-time Linux
+ Machinekit is the next-generation Enhanced Machine Controller which
+ provides motion control for CNC machine tools and robotic
+ applications (milling, cutting, routing, etc.).
+ .
+ This package provides components and drivers that run on an RT-Preempt system.

--- a/debian/control.xenomai-buster.in
+++ b/debian/control.xenomai-buster.in
@@ -1,0 +1,19 @@
+
+Package: machinekit-cnc-xenomai
+Architecture: any
+Provides:  machinekit-cnc-xenomai
+Breaks: machinekit
+Enhances: machinekit-hal-xenomai
+Depends: machinekit-hal-xenomai, python-gnome2, ${shlibs:Depends}, xenomai-runtime,
+    python-tk, python-pil, python-pil.imagetk, python-gst-1.0,
+    python-glade2, python-xlib, python-gtkglext1,
+    python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,
+    tcl8.6, tk8.6, bwidget (>= 1.7), libtk-img (>= 1.13), tclreadline, libgl1,
+    libglib2.0-0 (>= 2.12.0), libglu1-mesa | libglu1, libx11-6, libxaw7, libxt6
+Description: PC based motion controller for real-time Linux
+ Machinekit is the next-generation Enhanced Machine Controller which
+ provides motion control for CNC machine tools and robotic
+ applications (milling, cutting, routing, etc.).
+ .
+ This package provides components and drivers that run on a Xenomai
+ realtime system, with userspace threads.


### PR DESCRIPTION
Debian packages are in their usual state of turmoil.
python-vte exists in sid and every other distro except Buster at present.

Doubtless the sid package will be backported, but in the interim, packages
refuse to install without this fix on Buster