### PR TITLE
Python fdm: Add Hostmot2 driver support

### DIFF
--- a/lib/python/fdm/config/motion.py
+++ b/lib/python/fdm/config/motion.py
@@ -7,6 +7,17 @@ def setup_motion(kinematics='trivkins', tp='tp', num_aio=50, num_dio=21):
     rt.loadrt(kinematics)
     rt.loadrt(tp)
 
+
+    # hostmot2 setup  get names and config from ini file
+    hostmot2 = bool(c.find('HOSTMOT2', 'DRIVER'))
+    if hostmot2:
+        rt.loadrt('hostmot2')
+        rt.newinst(c.find('HOSTMOT2', 'DRIVER'),
+            c.find('HOSTMOT2', 'DEVNAME'),
+            "-- ",
+            c.find('HOSTMOT2', 'CONFIG'))
+
+
     # motion controller, get name and thread periods from ini file
     rt.loadrt(c.find('EMCMOT', 'EMCMOT'),
               servo_period_nsec=c.find('EMCMOT', 'SERVO_PERIOD'),


### PR DESCRIPTION
Signed-off-by: Michael Brown <producer@holotronic.dk>

This construction loads the hostmot2 driver (tested with hm2soc_ol) via the .ini file,
but only if somthing like this:
https://github.com/the-snowwhite/Hm2-soc_FDM/blob/master/Cramps/PY/OX/ox.ini#L1

    [HOSTMOT2]
    DRIVER=hm2_soc_ol
    BOARD=5i25
    CONFIG=config="firmware=socfpga/dtbo/DE0_Nano_SoC_Cramps.3x24_cap.dtbo num_pwmgens=1 
    num_stepgens=4"

    DEVNAME=hm2-socfpga0
is found in the .ini file