### PR TITLE
Fix warning: catching polymorphic type ‘error_already_set’ by value

### DIFF
--- a/src/emc/pythonplugin/python_plugin.cc
+++ b/src/emc/pythonplugin/python_plugin.cc
@@ -34,7 +34,7 @@ int PythonPlugin::run_string(const char *cmd, bp::object &retval, bool as_file)
 	    retval = bp::exec(cmd, main_namespace, main_namespace);
 	status = PLUGIN_OK;
     }
-    catch (bp::error_already_set) {
+    catch (bp::error_already_set &) {
 	if (PyErr_Occurred()) {
 	    exception_msg = handle_pyerror();
 	} else
@@ -61,7 +61,7 @@ int PythonPlugin::call_method(bp::object method, bp::object &retval)
 	retval = method(); 
 	status = PLUGIN_OK;
     }
-    catch (bp::error_already_set) {
+    catch (bp::error_already_set &) {
 	if (PyErr_Occurred()) {
 	   exception_msg = handle_pyerror();
 	} else
@@ -111,7 +111,7 @@ int PythonPlugin::call(const char *module, const char *callable,
 	    retval = bp::object();
 	status = PLUGIN_OK;
     }
-    catch (bp::error_already_set) {
+    catch (bp::error_already_set &) {
 	if (PyErr_Occurred()) {
 	   exception_msg = handle_pyerror();
 	} else
@@ -151,7 +151,7 @@ bool PythonPlugin::is_callable(const char *module,
 	}
 	result = PyCallable_Check(function.ptr());
     }
-    catch (bp::error_already_set) {
+    catch (bp::error_already_set &) {
 	// KeyError expected if not callable
 	if (!PyErr_ExceptionMatches(PyExc_KeyError)) {
 	    // something else, strange
@@ -234,7 +234,7 @@ int PythonPlugin::initialize()
 						  main_namespace);
 	    status = PLUGIN_OK;
 	}
-	catch (bp::error_already_set) {
+	catch (bp::error_already_set &) {
 	    if (PyErr_Occurred()) {
 		exception_msg = handle_pyerror();
 	    } else

--- a/src/emc/rs274ngc/interp_python.cc
+++ b/src/emc/rs274ngc/interp_python.cc
@@ -131,7 +131,7 @@ int Interp::pycall(setup_pointer settings,
 	try {
 	    retval = frame->generator_next();
 	}
-	catch (bp::error_already_set) {
+	catch (bp::error_already_set &) {
 	    if (PyErr_Occurred()) {
 		// StopIteration is raised when the generator executes 'return'
 		// instead of another 'yield INTERP_EXECUTE_FINISH
@@ -249,7 +249,7 @@ int Interp::pycall(setup_pointer settings,
 	default: ;
 	}
     }
-    catch (bp::error_already_set) {
+    catch (bp::error_already_set &) {
 	if (PyErr_Occurred()) {
 	    msg = handle_pyerror();
 	}

--- a/src/emc/rs274ngc/interp_remap.cc
+++ b/src/emc/rs274ngc/interp_remap.cc
@@ -219,7 +219,7 @@ int Interp::add_parameters(setup_pointer settings,
 	try {								\
 	    active_frame->kwargs[name] = value;				\
         }								\
-        catch (bp::error_already_set) {					\
+        catch (bp::error_already_set &) {				\
 	    PyErr_Print();						\
 	    PyErr_Clear();						\
 	    ERS("add_parameters: cant add '%s' to args",name);		\

--- a/src/emc/rs274ngc/rs274ngc_pre.cc
+++ b/src/emc/rs274ngc/rs274ngc_pre.cc
@@ -139,7 +139,7 @@ Interp::Interp()
 	bp::object retval;
 	python_plugin->run_string("from interpreter import this", retval, false);
     }
-    catch (bp::error_already_set) {
+    catch (bp::error_already_set &) {
 	std::string exception_msg;
 	if (PyErr_Occurred()) {
 	    exception_msg = handle_pyerror();
@@ -1217,7 +1217,7 @@ int Interp::init()
 	      }
 	  }
       }
-      catch (bp::error_already_set) {
+      catch (bp::error_already_set &) {
 	  std::string exception_msg;
 	  bool unexpected = false;
 	  // KeyError is ok - this means the namedparams module doesnt exist

--- a/src/emc/task/taskclass.cc
+++ b/src/emc/task/taskclass.cc
@@ -261,7 +261,7 @@ int emcIoInit() { return task_methods->emcIoInit(); }
 int emcIoHalt() {
     try {
 	return task_methods->emcIoHalt();
-    } catch( bp::error_already_set ) {
+    } catch( bp::error_already_set & ) {
 	std::string msg = handle_pyerror();
 	rcs_print("emcIoHalt(): %s\n", msg.c_str());
 	PyErr_Clear();
@@ -330,7 +330,7 @@ int emcTaskOnce(const char *filename)
 		rcs_print("cant extract a Task instance out of '%s'\n", instance_name);
 		task_methods = NULL;
 	    }
-	} catch( bp::error_already_set ) {
+	} catch( bp::error_already_set & ) {
 	    std::string msg = handle_pyerror();
 	    if (emc_debug & EMC_DEBUG_PYTHON_TASK) {
 		// this really just means the task python backend wasnt configured.

--- a/src/emc/task/taskmodule.cc
+++ b/src/emc/task/taskmodule.cc
@@ -45,7 +45,7 @@ static int handle_exception(const char *name)
 	    try {						\
 		return f();					\
 	    }							\
-	    catch( bp::error_already_set ) {			\
+	    catch( bp::error_already_set & ) {			\
 		return handle_exception(#method);		\
 	    }							\
 	}							\
@@ -60,7 +60,7 @@ static int handle_exception(const char *name)
 	    try {							\
 		return f(name);						\
 	    }								\
-	    catch( bp::error_already_set ) {				\
+	    catch( bp::error_already_set & ) {				\
 		return handle_exception(#method);			\
 	    }								\
 	} else								\
@@ -74,7 +74,7 @@ static int handle_exception(const char *name)
 	    try {							\
 		return f(name,name2);					\
 	    }								\
-	    catch( bp::error_already_set ) {				\
+	    catch( bp::error_already_set & ) {				\
 		return handle_exception(#method);			\
 	    }								\
 	} else								\
@@ -113,7 +113,7 @@ struct TaskWrap : public Task, public bp::wrapper<Task> {
 		std::string buffer(msg,len);
 		return f(len,buffer);
 	    }
-	    catch( bp::error_already_set ) {
+	    catch( bp::error_already_set & ) {
 		return handle_exception("emcIoPluginCall");
 	    }
 	} else
@@ -126,7 +126,7 @@ struct TaskWrap : public Task, public bp::wrapper<Task> {
 	    try {
 		return f(pocket,toolno,offset,diameter,frontangle,backangle,orientation);
 	    }
-	    catch( bp::error_already_set ) {
+	    catch( bp::error_already_set & ) {
 		return handle_exception("emcToolSetOffset");
 	    }
 	else
@@ -138,7 +138,7 @@ struct TaskWrap : public Task, public bp::wrapper<Task> {
 	    try {
 		return f(); /// bug in Boost.Python, fixed in 1.44 I guess: return_int("foo",f());
 	    }
-	    catch( bp::error_already_set ) {
+	    catch( bp::error_already_set & ) {
 		return handle_exception("emcIoUpdate");
 	    }
 	else


### PR DESCRIPTION
Catch by reference instead of by value.