### PR TITLE
emcmodule: Do not use memcpy to copy non-trivial types

### DIFF
--- a/src/emc/usr_intf/axis/extensions/emcmodule.cc
+++ b/src/emc/usr_intf/axis/extensions/emcmodule.cc
@@ -281,7 +281,7 @@ static PyObject *poll(pyStatChannel *s, PyObject *o) {
     if(!check_stat(s->c)) return NULL;
     if(s->c->peek() == EMC_STAT_TYPE) {
         EMC_STAT *emcStatus = static_cast<EMC_STAT*>(s->c->get_address());
-        memcpy(&s->status, emcStatus, sizeof(EMC_STAT));
+        s->status = *emcStatus;
     }
     Py_INCREF(Py_None);
     return Py_None;


### PR DESCRIPTION
This fixes:

emc/usr_intf/axis/extensions/emcmodule.cc:284:55: warning: ‘void* memcpy(void*, const void*, size_t)’ writing to an object of type ‘class EMC_STAT’ with no trivial copy-assignment; use copy-assignment or copy-initialization instead [-Wclass-memaccess]