### PR TITLE
configure: Exit configure with an error, if boost::python is not found

### DIFF
--- a/src/configure.ac
+++ b/src/configure.ac
@@ -3087,6 +3087,9 @@ Install this version and specify --with-tcl and --with-tk if necessary])
     # Get the CFLAGS and LIBS for boost::python.
     AX_BOOST_BASE(1.34, , [AC_MSG_ERROR([Boost 1.34.0 or newer required])])
     AX_BOOST_PYTHON
+    if test "$BOOST_PYTHON_LIB" = ""; then
+	AC_MSG_ERROR([boost::python missing.  Install it or specify --disable-python to skip the parts of Machinekit that depend on Python])
+    fi
 
     AC_MSG_CHECKING(for site-package location)
     SITEPY=`$PYTHON -c 'import distutils.sysconfig; print distutils.sysconfig.get_python_lib(1)'`


### PR DESCRIPTION
Otherwise the build will break later with a hard to understand linker failure:

g++ -g -Lmachinekit-hal/machinekit-cnc/lib -Wl,-rpath,machinekit-hal/machinekit-cnc/lib -Wl,--no-as-needed -Wl,-soname,libpyplugin.so.0 -shared -o ../lib/libpyplugin.so.0 objects/emc/pythonplugin/python_plugin.o objects/emc/pythonplugin/exec.o ../lib/liblinuxcncini.so -lstdc++ -l -lpython2.7
    /usr/bin/ld: cannot find -l-lpython2.7
    collect2: error: ld returned 1 exit status

Note the dangling -l before -lpython2.7.