### PR TITLE
Re-instate scripts to check git version changes

### DIFF
--- a/scripts/get-git-sha
+++ b/scripts/get-git-sha
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# return a short SHA for the current HEAD, or text describing the situation
+
+gitcmd=`which git`
+if test -n "$gitcmd"; then
+   short_sha=`git rev-parse --short HEAD  2>/dev/null`
+   if test -n "$short_sha"; then
+       echo $short_sha
+   else
+       echo 'not in a git repo'
+   fi
+else
+   echo 'git not installed or executable'
+fi
+exit 0

--- a/scripts/get-version-from-git
+++ b/scripts/get-version-from-git
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+if [ ! -z "$EMC2_HOME" ]; then
+    source $EMC2_HOME/scripts/githelper.sh
+else
+    if [ ! -d debian -o ! -d src ]; then
+        echo "this script must be run from the root of the source tree (the directory with debian and src in it)"
+        exit 1
+    fi
+    source scripts/githelper.sh
+fi
+
+githelper $1
+
+if [ "$DEB_COMPONENT" = "scratch" ]; then
+    # unknown branches get the VERSION file, plus the branch name (with any
+    # characters that are invalid in debian version numbers replaced with
+    # dashes '-'), plus the HEAD commit SHA1
+    echo v$(git show HEAD:VERSION | cut -d ' ' -f 1)~${GIT_BRANCH//[^-.+:~a-z0-9]/-}~$(git show --pretty=format:%h HEAD | head -1)
+else
+    # known branches get the "describe" of the most recent signed git tag,
+    # or of the most recent unsigned tag if no signed tags are found
+    git describe --match "$GIT_TAG"
+fi
+

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -1,0 +1,90 @@
+#
+# This is a bash shell fragment, intended to be sourced by scripts that
+# want to work with git in the emc2 repo.
+#
+# Sets GIT_BRANCH to the passed in branch name; if none is passed in it
+# attempts to detect the current branch (this will fail if the repo is in a
+# detached HEAD state).
+#
+# Sets DEB_COMPONENT based on the branch.  Official release branches get
+# their own component, all other branches go in "scratch".
+#
+# Sets GIT_TAG to the most recent signed tag (this will fall back to the
+# most recent tag of any kind if no signed tag is found).
+#
+
+
+function githelper() {
+    if [ -z "$1" ]; then
+        GIT_BRANCH=$(git branch | egrep '^\*' | cut -d ' ' -f 2)
+        if [ "$GIT_BRANCH" = "(no" ]; then
+            echo "'git branch' says we're not on a branch, pass one in as an argument" > /dev/null 1>&2
+            return
+        fi
+    else
+        GIT_BRANCH="$1"
+    fi
+
+    case $GIT_BRANCH in
+        master)
+            GIT_TAG_GLOB="v2.7*"
+            DEB_COMPONENT="master"
+            ;;
+        2.6)
+            GIT_TAG_GLOB="v2.6*"
+            DEB_COMPONENT="2.6"
+            ;;
+        v2.5_branch)
+            GIT_TAG_GLOB="v2.5*"
+            DEB_COMPONENT="v2.5_branch"
+            ;;
+        v2.4_branch)
+            GIT_TAG_GLOB="v2.4*"
+            DEB_COMPONENT="v2.4_branch"
+            ;;
+        *)
+            GIT_TAG_GLOB="*"
+            DEB_COMPONENT="scratch"
+            ;;
+    esac
+
+
+    NEWEST_SIGNED_TAG_UTIME=-1
+    NEWEST_UNSIGNED_TAG_UTIME=-1
+    for TAG in $(git tag -l "$GIT_TAG_GLOB"); do
+        if ! git cat-file tag $TAG > /dev/null 2> /dev/null; then
+            continue
+        fi
+
+        TAG_UTIME=$(git cat-file tag $TAG | grep tagger | awk '{print $(NF-1)-$NF*36}')
+
+        if git tag -v "$TAG" > /dev/null 2> /dev/null; then
+            # it's a valid signed tag
+            if [ $TAG_UTIME -gt $NEWEST_SIGNED_TAG_UTIME ]; then
+                NEWEST_SIGNED_TAG=$TAG
+                NEWEST_SIGNED_TAG_UTIME=$TAG_UTIME
+            fi
+        else
+            # unsigned tag
+            if [ $TAG_UTIME -gt $NEWEST_UNSIGNED_TAG_UTIME ]; then
+                NEWEST_UNSIGNED_TAG=$TAG
+                NEWEST_UNSIGNED_TAG_UTIME=$TAG_UTIME
+            fi
+        fi
+
+    done
+
+    if [ $NEWEST_SIGNED_TAG_UTIME -gt -1 ]; then
+        GIT_TAG="$NEWEST_SIGNED_TAG"
+        return
+    fi
+
+    if [ $NEWEST_UNSIGNED_TAG_UTIME -gt -1 ]; then
+        echo "no signed tags found, falling back to unsigned tags" > /dev/null 1>&2
+        GIT_TAG="$NEWEST_UNSIGNED_TAG"
+        return
+    fi
+
+    echo "no annotated tags found, not even unsigned" > /dev/null 1>&2
+}
+

--- a/scripts/githelper.sh
+++ b/scripts/githelper.sh
@@ -27,20 +27,8 @@ function githelper() {
 
     case $GIT_BRANCH in
         master)
-            GIT_TAG_GLOB="v2.7*"
+            GIT_TAG_GLOB="master*"
             DEB_COMPONENT="master"
-            ;;
-        2.6)
-            GIT_TAG_GLOB="v2.6*"
-            DEB_COMPONENT="2.6"
-            ;;
-        v2.5_branch)
-            GIT_TAG_GLOB="v2.5*"
-            DEB_COMPONENT="v2.5_branch"
-            ;;
-        v2.4_branch)
-            GIT_TAG_GLOB="v2.4*"
-            DEB_COMPONENT="v2.4_branch"
             ;;
         *)
             GIT_TAG_GLOB="*"


### PR DESCRIPTION
Largely irrelevant in main package builds, but in RIPs will warn
of changes which should necessitate a full rebuild.

Fixes #78 

Signed-off-by: Mick <arceye@mgware.co.uk>