### PR TITLE
Remove dependency on python-gnome2 package

### DIFF
--- a/debian/control.posix-stretch.in
+++ b/debian/control.posix-stretch.in
@@ -4,7 +4,7 @@ Architecture: any
 Provides:  machinekit-cnc-posix
 Breaks: machinekit
 Enhances: machinekit-hal-posix
-Depends: machinekit-hal-posix, ${shlibs:Depends}, python-gnome2, 
+Depends: machinekit-hal-posix, ${shlibs:Depends}, 
     python-tk, python-pil, python-pil.imagetk, python-gst-1.0,
     python-glade2, python-vte, python-xlib, python-gtkglext1, 
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot, 

--- a/debian/control.posix.in
+++ b/debian/control.posix.in
@@ -4,7 +4,7 @@ Architecture: any
 Provides:  machinekit-cnc-posix
 Breaks: machinekit
 Enhances: machinekit-hal-posix
-Depends: machinekit-hal-posix, ${shlibs:Depends}, python-gnome2, 
+Depends: machinekit-hal-posix, ${shlibs:Depends}, 
     python-tk, python-imaging, python-imaging-tk, python-gst-0.10,
     python-glade2, python-vte, python-xlib, python-gtkglext1, 
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot, 

--- a/debian/control.rt-preempt-stretch.in
+++ b/debian/control.rt-preempt-stretch.in
@@ -4,7 +4,7 @@ Architecture: any
 Provides:  machinekit-cnc-rt-preempt
 Breaks: machinekit
 Enhances: machinekit-hal-rt-preempt
-Depends: machinekit-hal-rt-preempt, python-gnome2, ${shlibs:Depends},
+Depends: machinekit-hal-rt-preempt, ${shlibs:Depends},
     linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64],
     python-tk, python-pil, python-pil.imagetk, python-gst-1.0,
     python-glade2, python-vte, python-xlib, python-gtkglext1,

--- a/debian/control.rt-preempt.in
+++ b/debian/control.rt-preempt.in
@@ -4,7 +4,7 @@ Architecture: any
 Provides:  machinekit-cnc-rt-preempt
 Breaks: machinekit
 Enhances: machinekit-hal-rt-preempt
-Depends: machinekit-hal-rt-preempt, python-gnome2, ${shlibs:Depends},
+Depends: machinekit-hal-rt-preempt, ${shlibs:Depends},
     linux-image-rt-686-pae [i386], linux-image-rt-amd64 [amd64],
     python-tk, python-imaging, python-imaging-tk, python-gst-0.10,
     python-glade2, python-vte, python-xlib, python-gtkglext1,

--- a/debian/control.xenomai-stretch.in
+++ b/debian/control.xenomai-stretch.in
@@ -4,7 +4,7 @@ Architecture: any
 Provides:  machinekit-cnc-xenomai
 Breaks: machinekit
 Enhances: machinekit-hal-xenomai
-Depends: machinekit-hal-xenomai, python-gnome2, ${shlibs:Depends}, xenomai-runtime,
+Depends: machinekit-hal-xenomai, ${shlibs:Depends}, xenomai-runtime,
     python-tk, python-pil, python-pil.imagetk, python-gst-1.0,
     python-glade2, python-vte, python-xlib, python-gtkglext1,
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,

--- a/debian/control.xenomai.in
+++ b/debian/control.xenomai.in
@@ -4,7 +4,7 @@ Architecture: any
 Provides:  machinekit-cnc-xenomai
 Breaks: machinekit
 Enhances: machinekit-hal-xenomai
-Depends: machinekit-hal-xenomai, python-gnome2, ${shlibs:Depends}, xenomai-runtime,
+Depends: machinekit-hal-xenomai, ${shlibs:Depends}, xenomai-runtime,
     python-tk, python-imaging, python-imaging-tk, python-gst-0.10,
     python-glade2, python-vte, python-xlib, python-gtkglext1,
     python-configobj, python-simplejson, python-pyftpdlib, python-pydot, xdot,


### PR DESCRIPTION
Removing the Machinekit-CNC dependency on python-gnome2 causing problems on Debian Buster as outlined in machinekit/machinekit#1323.

Given the fact that by LinuxCNC discussion the only part which uses this module is (probably) HALGUI, nothing really should be affected. (Discussed in LinuxCNC/linuxcnc#341)

HALGUI is still part of Machinekit-HAL. LinuxCNC solved this issue by deleting the HALGUI code (my guess is that nobody uses it). Pertinent commit LinuxCNC/linuxcnc@2f12e4567ac30b307db4fae31ebe97e7a19e1725. So -maybe - it should be removed from Machinekit-HAL too.



